### PR TITLE
Update stateless app definition && typo

### DIFF
--- a/application-development.md
+++ b/application-development.md
@@ -481,7 +481,7 @@ The VPA is currently in beta and is **not recommended for production**. Given th
 
 The [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) is another type of "autoscaler" (besides the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) and [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)).
 
-The Cluster Autoscaler can automatically add or remove worker nodes from your cluster. It becomes active when a Pod can't be scheduled to one of the existing nodes because of inefficient resources. In that case, the Cluster Autoscaler will create a new worker node, so that the Pod can be scheduled.
+The Cluster Autoscaler can automatically add or remove worker nodes from your cluster. It becomes active when a Pod can't be scheduled to one of the existing nodes because of insufficient resources. In that case, the Cluster Autoscaler will create a new worker node, so that the Pod can be scheduled.
 
 Configuring the Cluster Autoscaler includes some overhead, and another downside is that it only becomes active when a Pod already failed to schedule. Given that it takes some time to spin up a new worker node, this can result in a considerable delay until the Pods can finally run.
 

--- a/application-development.md
+++ b/application-development.md
@@ -453,7 +453,7 @@ You could save on running an extra container for each Pod in your cluster.
 
 ### The app is stateless
 
-A containerised app is stateless if it doesn't store any state in the local filesystem of its container.
+A containerised app is stateless if it **does not** store any information about previous requests. That is to say no information will be stored on the local filesystem nor in memory within its container, and every run will be fresh and uninformed from prior decisions. 
 
 For an app to be horizontally scalable, it must be stateless. The reason is that if each container stores its own state, there is no "ground truth" and the states saved by each container may diverge. This results in inconsistent behaviour (for example, a certain piece of data is available in one Pod, but not in another).
 


### PR DESCRIPTION
Cool article, sent it off to some coworkers today, but I had some thoughts around the definition of statelessness. From the first commit message (since I was lazy and edited on the UI):

Increase clarity of statelessness. 
>An app is stateless if it doesn't store any state
The above is, while super obvious, not helpful to the uninformed reader. 

Grabbing the first definition in Google, from [whatis.techtarget.com](https://whatis.techtarget.com/definition/stateless-app)
>A stateless app is an application program that does not save client data generated in one session for use in the next session with that client. Each session is carried out as if it was the first time and responses are not dependent upon data from a previous session. In contrast, a stateful application saves data about each client session and uses that data the next time the client makes a request.
